### PR TITLE
Delete cancel mint by minter

### DIFF
--- a/src/Protocol.sol
+++ b/src/Protocol.sol
@@ -134,12 +134,12 @@ contract Protocol is IProtocol, ContinuousIndexing, StatelessERC712 {
         updateIndex();
     }
 
-    function cancelMint(uint256 mintId_) external onlyActiveMinter {
-        _cancelMint(msg.sender, mintId_);
-    }
-
     function cancelMint(address minter_, uint256 mintId_) external onlyApprovedValidator {
-        _cancelMint(minter_, mintId_);
+        if (_mintProposals[minter_].id != mintId_) revert InvalidMintProposal();
+
+        delete _mintProposals[minter_];
+
+        emit MintCanceled(mintId_, msg.sender);
     }
 
     function deactivateMinter(address minter_) external returns (uint256 inactiveOwedM_) {
@@ -428,14 +428,6 @@ contract Protocol is IProtocol, ContinuousIndexing, StatelessERC712 {
     /******************************************************************************************************************\
     |                                          Internal Interactive Functions                                          |
     \******************************************************************************************************************/
-
-    function _cancelMint(address minter_, uint256 mintId_) internal {
-        if (_mintProposals[minter_].id != mintId_) revert InvalidMintProposal();
-
-        delete _mintProposals[minter_];
-
-        emit MintCanceled(mintId_, msg.sender);
-    }
 
     function _imposePenalty(address minter_, uint256 penaltyBase_) internal {
         // TODO: The rate being charged for a late interval should be M per active owed M.

--- a/src/interfaces/IProtocol.sol
+++ b/src/interfaces/IProtocol.sol
@@ -120,14 +120,6 @@ interface IProtocol is IContinuousIndexing {
     function burnM(address minter, uint256 amount) external;
 
     /**
-     * @notice Cancels minting request for minter
-     * @dev MUST only be callable by an active minter
-     * @dev An active minter that is not approved by SPOG Registrar anymore can still call cancelMint
-     * @param mintId The id of outstanding mint request
-     */
-    function cancelMint(uint256 mintId) external;
-
-    /**
      * @notice Cancels minting request for selected minter by validator
      * @param minter The address of the minter to cancelMint minting request for
      * @param mintId The id of outstanding mint request


### PR DESCRIPTION
Minter can 
- not mint 
- replace the current mint proposal with a new one, instead of canceling.