### PR TITLE
Add fixes for mint id

### DIFF
--- a/src/Protocol.sol
+++ b/src/Protocol.sol
@@ -225,10 +225,8 @@ contract Protocol is IProtocol, ContinuousIndexing, ERC712 {
         _revertIfUndercollateralized(msg.sender, amount_); // Check that minter will remain sufficiently collateralized.
 
         unchecked {
-            _mintNonce++;
+            mintId_ = ++_mintNonce;
         }
-
-        mintId_ = uint256(keccak256(abi.encode(msg.sender, amount_, destination_, _mintNonce)));
 
         _mintProposals[msg.sender] = MintProposal(mintId_, destination_, amount_, block.timestamp);
 
@@ -237,10 +235,8 @@ contract Protocol is IProtocol, ContinuousIndexing, ERC712 {
 
     function proposeRetrieval(uint256 collateral_) external onlyActiveMinter returns (uint256 retrievalId_) {
         unchecked {
-            _retrievalNonce++;
+            retrievalId_ = ++_retrievalNonce;
         }
-
-        retrievalId_ = uint256(keccak256(abi.encode(msg.sender, collateral_, _retrievalNonce)));
 
         _totalPendingCollateralRetrieval[msg.sender] += collateral_;
         _pendingRetrievals[msg.sender][retrievalId_] = collateral_;

--- a/test/Protocol.t.sol
+++ b/test/Protocol.t.sol
@@ -282,7 +282,7 @@ contract ProtocolTests is Test {
         _protocol.setLastCollateralUpdateOf(_minter1, block.timestamp);
         _protocol.setLastUpdateIntervalOf(_minter1, _updateCollateralInterval);
 
-        uint256 expectedMintId = _protocol.getMintId(_minter1, amount, _alice, _protocol.mintNonce() + 1);
+        uint256 expectedMintId = _protocol.mintNonce() + 1;
 
         vm.expectEmit();
         emit MintProposed(expectedMintId, _minter1, amount, _alice);
@@ -581,7 +581,7 @@ contract ProtocolTests is Test {
         // fast-forward to the time when minter is unfrozen
         vm.warp(frozenUntil);
 
-        uint256 expectedMintId = _protocol.getMintId(_minter1, amount, _alice, _protocol.mintNonce() + 1);
+        uint256 expectedMintId = _protocol.mintNonce() + 1;
 
         vm.expectEmit();
         emit MintProposed(expectedMintId, _minter1, amount, _alice);
@@ -1195,7 +1195,7 @@ contract ProtocolTests is Test {
         vm.prank(_minter1);
         _protocol.updateCollateral(collateral, retrievalIds, bytes32(0), validators, timestamps, signatures);
 
-        uint256 expectedRetrievalId = _protocol.getRetrievalId(_minter1, collateral, _protocol.retrievalNonce() + 1);
+        uint256 expectedRetrievalId = _protocol.retrievalNonce() + 1;
 
         vm.expectEmit();
         emit RetrievalCreated(expectedRetrievalId, _minter1, collateral);
@@ -1288,11 +1288,7 @@ contract ProtocolTests is Test {
         _protocol.setPrincipalOfActiveOwedMOf(_minter1, amount);
 
         uint256 retrievalAmount = 10e18;
-        uint256 expectedRetrievalId = _protocol.getRetrievalId(
-            _minter1,
-            retrievalAmount,
-            _protocol.retrievalNonce() + 1
-        );
+        uint256 expectedRetrievalId = _protocol.retrievalNonce() + 1;
 
         // First retrieval proposal
         vm.expectEmit();

--- a/test/utils/ProtocolHarness.sol
+++ b/test/utils/ProtocolHarness.sol
@@ -15,19 +15,6 @@ contract ProtocolHarness is Protocol {
         return _retrievalNonce;
     }
 
-    function getMintId(
-        address minter_,
-        uint256 amount_,
-        address destination_,
-        uint256 nonce_
-    ) external pure returns (uint256) {
-        return uint256(keccak256(abi.encode(minter_, amount_, destination_, nonce_)));
-    }
-
-    function getRetrievalId(address minter_, uint256 collateral_, uint256 nonce_) external pure returns (uint256) {
-        return uint256(keccak256(abi.encode(minter_, collateral_, nonce_)));
-    }
-
     function setActiveMinter(address minter_, bool isActive_) external {
         _isActiveMinter[minter_] = isActive_;
     }


### PR DESCRIPTION
Use `mintNonce` and `retrievalNonce` as ids of mint and retrieval requests. 