### PR TITLE
fix: empty RateModel bug

### DIFF
--- a/src/MToken.sol
+++ b/src/MToken.sol
@@ -347,7 +347,7 @@ contract MToken is IMToken, ContinuousIndexing, ERC20Permit {
             abi.encodeWithSelector(IRateModel.rate.selector)
         );
 
-        rate_ = success_ ? abi.decode(returnData_, (uint256)) : 0;
+        rate_ = (success_ && returnData_.length >= 32) ? abi.decode(returnData_, (uint256)) : 0;
     }
 
     /**

--- a/src/Protocol.sol
+++ b/src/Protocol.sol
@@ -17,7 +17,7 @@ import { ContinuousIndexing } from "./ContinuousIndexing.sol";
 /**
  * @title Protocol
  * @author M^ZERO LABS_
- * @notice Core protocol of M^ZERO ecosystem. 
+ * @notice Core protocol of M^ZERO ecosystem.
            Minting Gateway of M Token for all approved by SPOG and activated minters.
  */
 contract Protocol is IProtocol, ContinuousIndexing, ERC712 {
@@ -704,7 +704,7 @@ contract Protocol is IProtocol, ContinuousIndexing, ERC712 {
             abi.encodeWithSelector(IRateModel.rate.selector)
         );
 
-        rate_ = success_ ? abi.decode(returnData_, (uint256)) : 0;
+        rate_ = (success_ && returnData_.length >= 32) ? abi.decode(returnData_, (uint256)) : 0;
     }
 
     /**

--- a/test/MToken.t.sol
+++ b/test/MToken.t.sol
@@ -645,4 +645,10 @@ contract MTokenTests is Test {
 
         assertEq(_mToken.hasOptedOutOfEarning(_alice), true);
     }
+
+    function test_emptyRateModel() external {
+        _registrar.updateConfig(SPOGRegistrarReader.EARNER_RATE_MODEL, address(0));
+
+        assertEq(_mToken.rate(), 0);
+    }
 }

--- a/test/Protocol.t.sol
+++ b/test/Protocol.t.sol
@@ -1445,6 +1445,12 @@ contract ProtocolTests is Test {
         assertEq(_protocol.collateralUpdateOf(_minter1), block.timestamp);
     }
 
+    function test_emptyRateModel() external {
+        _spogRegistrar.updateConfig(SPOGRegistrarReader.MINTER_RATE_MODEL, address(0));
+
+        assertEq(_protocol.rate(), 0);
+    }
+
     function _getCollateralUpdateSignature(
         address minter,
         uint256 collateral,

--- a/test/utils/MTokenHarness.sol
+++ b/test/utils/MTokenHarness.sol
@@ -46,4 +46,8 @@ contract MTokenHarness is MToken {
     function totalPrincipalOfEarningSupply() external view returns (uint256 totalPrincipalOfEarningSupply_) {
         return _totalPrincipalOfEarningSupply;
     }
+
+    function rate() external view returns (uint256 rate_) {
+        return _rate();
+    }
 }

--- a/test/utils/ProtocolHarness.sol
+++ b/test/utils/ProtocolHarness.sol
@@ -61,4 +61,8 @@ contract ProtocolHarness is Protocol {
     function principalOfActiveOwedMOf(address minter_) external view returns (uint256 principalOfActiveOwedM_) {
         return _principalOfActiveOwedM[minter_];
     }
+
+    function rate() external view returns (uint256 rate_) {
+        return _rate();
+    }
 }


### PR DESCRIPTION
`_rate()` was supposed to return 0 for any issue (revert or otherwise) in fetching a rate from the RateModel contract, but I overlooked the possibility that the contract has a succeeding fallback, and that the return data size did not exist.