### PR TITLE
refactor: Searching for a better name for MinterBasic

### DIFF
--- a/test/utils/ProtocolHarness.sol
+++ b/test/utils/ProtocolHarness.sol
@@ -18,7 +18,7 @@ contract ProtocolHarness is Protocol {
     }
 
     function setActiveMinter(address minter_, bool isActive_) external {
-        _minterBasics[minter_].isActive = isActive_;
+        _minterStates[minter_].isActive = isActive_;
     }
 
     function setMintProposalOf(
@@ -38,19 +38,19 @@ contract ProtocolHarness is Protocol {
     }
 
     function setCollateralOf(address minter_, uint256 collateral_) external {
-        _minterBasics[minter_].collateral = UIntMath.safe128(collateral_);
+        _minterStates[minter_].collateral = UIntMath.safe128(collateral_);
     }
 
     function setCollateralUpdateOf(address minter_, uint256 lastUpdated_) external {
-        _minterBasics[minter_].updateTimestamp = uint40(lastUpdated_);
+        _minterStates[minter_].updateTimestamp = uint40(lastUpdated_);
     }
 
     function setLastCollateralUpdateIntervalOf(address minter_, uint256 updateInterval_) external {
-        _minterBasics[minter_].lastUpdateInterval = uint32(updateInterval_);
+        _minterStates[minter_].lastUpdateInterval = uint32(updateInterval_);
     }
 
     function setPenalizedUntilOf(address minter_, uint256 penalizedUntil_) external {
-        _minterBasics[minter_].penalizedUntilTimestamp = uint40(penalizedUntil_);
+        _minterStates[minter_].penalizedUntilTimestamp = uint40(penalizedUntil_);
     }
 
     function setPrincipalOfActiveOwedMOf(address minter_, uint256 amount_) external {


### PR DESCRIPTION
Aside from a TODO I think is important we leave at the top (that all optimizations are not yet concrete due to inadequate gas reporting), we should use this PR to discuss a better name for `MinterBasic` that is unambiguous, descriptive, concise, and grammatically correct.

Also, `@dev` for internal storage variables (and functions) are probably better than `@notice`, since:
- `@notice` is for userdoc, and user's cannot interact with these functions/variables
- devs are more likely to care about these comments