### PR TITLE
fix: resolve inconsistency between collateral expiration and collateralOf

### DIFF
--- a/src/MinterGateway.sol
+++ b/src/MinterGateway.sol
@@ -504,7 +504,7 @@ contract MinterGateway is IMinterGateway, ContinuousIndexing, ERC712 {
     /// @inheritdoc IMinterGateway
     function collateralOf(address minter_) public view returns (uint240) {
         // If collateral was not updated by the deadline, assume that minter's collateral is zero.
-        if (block.timestamp > collateralExpiryTimestampOf(minter_)) return 0;
+        if (block.timestamp >= collateralExpiryTimestampOf(minter_)) return 0;
 
         uint240 totalPendingRetrievals_ = _minterStates[minter_].totalPendingRetrievals;
         uint240 collateral_ = _minterStates[minter_].collateral;

--- a/test/integration/minter-gateway/update-collateral/updateCollateral.t.sol
+++ b/test/integration/minter-gateway/update-collateral/updateCollateral.t.sol
@@ -108,7 +108,7 @@ contract UpdateCollateral_IntegrationTest is IntegrationBaseSetup {
         uint128 updateCollateralIndex_ = _minterGateway.latestIndex();
         assertEq(_minterGateway.latestIndex(), _minterGateway.currentIndex());
 
-        _registrar.updateConfig(TTGRegistrarReader.UPDATE_COLLATERAL_INTERVAL, 1 hours);
+        _registrar.updateConfig(TTGRegistrarReader.UPDATE_COLLATERAL_INTERVAL, 1 hours + 1 seconds);
 
         vm.warp(block.timestamp + 12 hours);
 


### PR DESCRIPTION
Make `collateralOf` and missed intervals calculation consistent. If missed interval == 1, `collateralOf(minter)` == 0. 

[cs-mzerocore-11](https://drive.google.com/file/d/1zVBQduPBGvWQAXpmTDihbKRoGIFaxZKQ/view?usp=drive_link)