### PR TITLE
fix: add checks for insufficient balance in transfer

### DIFF
--- a/src/MToken.sol
+++ b/src/MToken.sol
@@ -307,9 +307,12 @@ contract MToken is IMToken, ContinuousIndexing, ERC20Extended {
      * @param principalAmount_ The principal amount to subtract.
      */
     function _subtractEarningAmount(address account_, uint112 principalAmount_) internal {
-        _balances[account_].rawBalance -= principalAmount_;
+        uint256 fromBalance_ = _balances[account_].rawBalance;
+        if (fromBalance_ < principalAmount_) revert InsufficientBalance(account_, fromBalance_, principalAmount_);
 
         unchecked {
+            // Overflow not possible: principalAmount_ <= fromBalance_.
+            _balances[account_].rawBalance -= principalAmount_;
             principalOfTotalEarningSupply -= principalAmount_;
         }
     }
@@ -320,9 +323,12 @@ contract MToken is IMToken, ContinuousIndexing, ERC20Extended {
      * @param amount_  The amount to subtract.
      */
     function _subtractNonEarningAmount(address account_, uint240 amount_) internal {
-        _balances[account_].rawBalance -= amount_;
+        uint256 fromBalance_ = _balances[account_].rawBalance;
+        if (fromBalance_ < amount_) revert InsufficientBalance(account_, fromBalance_, amount_);
 
         unchecked {
+            // Overflow not possible: amount_ <= fromBalance_.
+            _balances[account_].rawBalance -= amount_;
             totalNonEarningSupply -= amount_;
         }
     }

--- a/src/interfaces/IMToken.sol
+++ b/src/interfaces/IMToken.sol
@@ -33,6 +33,9 @@ interface IMToken is IContinuousIndexing, IERC20Extended {
     ///  @notice Emitted in constructor if TTG Registrar is 0x0.
     error ZeroTTGRegistrar();
 
+    /// @notice Emitted when calling `transfer` if sender's raw balance is insufficient.
+    error InsufficientBalance(address sender, uint256 rawBalance, uint256 needed);
+
     /******************************************************************************************************************\
     |                                                     Events                                                       |
     \******************************************************************************************************************/

--- a/test/MToken.t.sol
+++ b/test/MToken.t.sol
@@ -212,7 +212,7 @@ contract MTokenTests is TestUtils {
     function test_burn_insufficientBalance_fromNonEarner() external {
         _mToken.setInternalBalanceOf(_alice, 999);
 
-        vm.expectRevert(stdError.arithmeticError);
+        vm.expectRevert(abi.encodeWithSelector(IMToken.InsufficientBalance.selector, _alice, 999, 1_000));
         vm.prank(_minterGateway);
         _mToken.burn(_alice, 1_000);
     }
@@ -223,7 +223,7 @@ contract MTokenTests is TestUtils {
         _mToken.setIsEarning(_alice, true);
         _mToken.setInternalBalanceOf(_alice, 908);
 
-        vm.expectRevert(stdError.arithmeticError);
+        vm.expectRevert(abi.encodeWithSelector(IMToken.InsufficientBalance.selector, _alice, 908, 910));
         vm.prank(_minterGateway);
         _mToken.burn(_alice, 1_000);
     }
@@ -370,7 +370,7 @@ contract MTokenTests is TestUtils {
         _mToken.setIsEarning(_alice, true);
         _mToken.setInternalBalanceOf(_alice, 908);
 
-        vm.expectRevert(stdError.arithmeticError);
+        vm.expectRevert(abi.encodeWithSelector(IMToken.InsufficientBalance.selector, _alice, 908, 910));
         vm.prank(_alice);
         _mToken.transfer(_bob, 1_000);
     }


### PR DESCRIPTION
Add errors instead of underflow panic

[3Sigma I06](https://github.com/threesigmaxyz/mzero-labs-8-1-2024-issues-external/issues/19)