### PR TITLE
fix: prevent validator signatures before latest proposed retrieval

### DIFF
--- a/src/MinterGateway.sol
+++ b/src/MinterGateway.sol
@@ -583,7 +583,7 @@ contract MinterGateway is IMinterGateway, ContinuousIndexing, ERC712Extended {
     }
 
     /// @inheritdoc IMinterGateway
-    function latestProposedRetrievalOf(address minter_) external view returns (uint40) {
+    function latestProposedRetrievalTimestampOf(address minter_) external view returns (uint40) {
         return _minterStates[minter_].latestProposedRetrievalTimestamp;
     }
 

--- a/src/MinterGateway.sol
+++ b/src/MinterGateway.sol
@@ -124,6 +124,9 @@ contract MinterGateway is IMinterGateway, ContinuousIndexing, ERC712Extended {
     /// @dev The pending collateral retrievals of minter (retrieval ID, amount).
     mapping(address minter => mapping(uint48 retrievalId => uint240 amount)) internal _pendingCollateralRetrievals;
 
+    /// @dev The last update signature timestamp of each validator for each minter.
+    mapping(address minter => mapping(address validator => uint256 timestamp)) internal _lastSignatureTimestamp;
+
     /* ============ Modifiers ============ */
 
     /**
@@ -588,6 +591,11 @@ contract MinterGateway is IMinterGateway, ContinuousIndexing, ERC712Extended {
     }
 
     /// @inheritdoc IMinterGateway
+    function getLastSignatureTimestamp(address minter_, address validator_) external view returns (uint256) {
+        return _lastSignatureTimestamp[minter_][validator_];
+    }
+
+    /// @inheritdoc IMinterGateway
     function getPenaltyForMissedCollateralUpdates(address minter_) external view returns (uint240) {
         uint112 penaltyPrincipal_ = _getPenaltyPrincipalForMissedCollateralUpdates(minter_);
 
@@ -1021,7 +1029,7 @@ contract MinterGateway is IMinterGateway, ContinuousIndexing, ERC712Extended {
      * @param validator_ The address of the validator
      */
     function _revertIfNotApprovedValidator(address validator_) internal view {
-        if (!isValidatorApprovedByTTG(validator_)) revert NotApprovedValidator();
+        if (!isValidatorApprovedByTTG(validator_)) revert NotApprovedValidator(validator_);
     }
 
     /**
@@ -1064,58 +1072,92 @@ contract MinterGateway is IMinterGateway, ContinuousIndexing, ERC712Extended {
         address[] calldata validators_,
         uint256[] calldata timestamps_,
         bytes[] calldata signatures_
-    ) internal view returns (uint40 minTimestamp_) {
-        uint256 threshold_ = updateCollateralValidatorThreshold();
-
+    ) internal returns (uint40 minTimestamp_) {
         minTimestamp_ = uint40(block.timestamp);
 
-        // Stop processing if there are no more signatures or `threshold_` is reached.
-        for (uint256 index_; index_ < signatures_.length && threshold_ > 0; ++index_) {
+        uint256 validCount_;
+
+        for (uint256 index_; index_ < signatures_.length; ++index_) {
             unchecked {
                 // Check that validator address is unique and not accounted for
                 // NOTE: We revert here because this failure is entirely within the minter's control.
                 if (index_ > 0 && validators_[index_] <= validators_[index_ - 1]) revert InvalidSignatureOrder();
             }
 
-            // Check that validator is approved by TTG.
-            if (!isValidatorApprovedByTTG(validators_[index_])) continue;
-
-            // Check that the timestamp is not 0.
-            if (timestamps_[index_] == 0) revert ZeroTimestamp();
-
-            // Check that the timestamp is not in the future.
-            if (timestamps_[index_] > uint40(block.timestamp)) revert FutureTimestamp();
-
-            // NOTE: Need to store the variable here to avoid a stack too deep error.
-            bytes32 digest_ = _getUpdateCollateralDigest(
-                minter_,
-                collateral_,
-                retrievalIds_,
-                metadataHash_,
-                timestamps_[index_]
-            );
-
-            // Check that ECDSA or ERC1271 signatures for given digest are valid.
-            if (!SignatureChecker.isValidSignature(validators_[index_], digest_, signatures_[index_])) continue;
+            if (
+                !_verifyValidatorSignature(
+                    minter_,
+                    collateral_,
+                    retrievalIds_,
+                    metadataHash_,
+                    validators_[index_],
+                    timestamps_[index_],
+                    signatures_[index_]
+                )
+            ) continue;
 
             // Find minimum between all valid timestamps for valid signatures.
             minTimestamp_ = UIntMath.min40(minTimestamp_, uint40(timestamps_[index_]));
 
             unchecked {
-                --threshold_;
+                ++validCount_;
             }
         }
 
-        // NOTE: Due to STACK_TOO_DEEP issues, we need to refetch `requiredThreshold_` and compute the number of valid
-        //       signatures here, in order to emit the correct error message. However, the code will only reach this
-        //       point to inevitably revert, so the gas cost is not much of a concern.
-        if (threshold_ > 0) {
-            uint256 requiredThreshold_ = updateCollateralValidatorThreshold();
+        uint256 requiredThreshold_ = updateCollateralValidatorThreshold();
 
-            unchecked {
-                // NOTE: By this point, it is already established that `threshold_` is less than `requiredThreshold_`.
-                revert NotEnoughValidSignatures(requiredThreshold_ - threshold_, requiredThreshold_);
-            }
-        }
+        if (validCount_ < requiredThreshold_) revert NotEnoughValidSignatures(validCount_, requiredThreshold_);
+    }
+
+    /**
+     * @dev    Checks that a signature is a valid validator signature.
+     * @param  minter_       The address of the minter.
+     * @param  collateral_   The amount of collateral.
+     * @param  retrievalIds_ The list of outstanding collateral retrieval IDs to resolve.
+     * @param  metadataHash_ The hash of metadata of the collateral update, reserved for future informational use.
+     * @param  validator_    The address of a validator.
+     * @param  timestamp_    The timestamp for the collateral update signature.
+     * @param  signature_    The signature from the validator.
+     * @return Whether the signature is a valid validator signature or not.
+     */
+    function _verifyValidatorSignature(
+        address minter_,
+        uint256 collateral_,
+        uint256[] calldata retrievalIds_,
+        bytes32 metadataHash_,
+        address validator_,
+        uint256 timestamp_,
+        bytes calldata signature_
+    ) internal returns (bool) {
+        // Check that the timestamp is not 0.
+        // NOTE: Revert here because this failure is entirely within the minter's control.
+        if (timestamp_ == 0) revert ZeroTimestamp();
+
+        // Check that the timestamp is not in the future.
+        // NOTE: Revert here because this failure is entirely within the minter's control.
+        if (timestamp_ > uint40(block.timestamp)) revert FutureTimestamp();
+
+        uint256 lastTimestamp_ = _lastSignatureTimestamp[minter_][validator_];
+
+        // Check that the timestamp is not older than the last signature timestamp.
+        // NOTE: Revert here because this failure is entirely within the minter's control.
+        if (timestamp_ <= lastTimestamp_) revert OutdatedValidatorTimestamp(validator_, timestamp_, lastTimestamp_);
+
+        // Check that validator is approved by TTG.
+        if (!isValidatorApprovedByTTG(validator_)) return false;
+
+        // Check that ECDSA or ERC1271 signatures for given digest are valid.
+        if (
+            !SignatureChecker.isValidSignature(
+                validator_,
+                _getUpdateCollateralDigest(minter_, collateral_, retrievalIds_, metadataHash_, timestamp_),
+                signature_
+            )
+        ) return false;
+
+        // Save the last signature timestamp for the minter and validator combination.
+        _lastSignatureTimestamp[minter_][validator_] = timestamp_;
+
+        return true;
     }
 }

--- a/src/interfaces/IMinterGateway.sol
+++ b/src/interfaces/IMinterGateway.sol
@@ -130,7 +130,7 @@ interface IMinterGateway is IContinuousIndexing, IERC712 {
     /// @notice Emitted when calling `mintM` or `proposeMint` by a minter who was frozen by validator.
     error FrozenMinter();
 
-    /// @notice Emitted when calling `updateCollateral` if validator timestamp is in the future.
+    /// @notice Emitted when calling `updateCollateral` with any validator timestamp in the future.
     error FutureTimestamp();
 
     /// @notice Emitted when calling a function only allowed for active minters.
@@ -145,8 +145,8 @@ interface IMinterGateway is IContinuousIndexing, IERC712 {
     /// @notice Emitted when calling `activateMinter` if minter was not approved by TTG.
     error NotApprovedMinter();
 
-    /// @notice Emitted when calling `cancelMint` or `freezeMinter` if validator was not approved by TTG.
-    error NotApprovedValidator();
+    /// @notice Emitted when calling `cancelMint` or `freezeMinter` if `validator` was not approved by TTG.
+    error NotApprovedValidator(address validator);
 
     /// @notice Emitted when calling `updateCollateral` if `validatorThreshold` of signatures was not reached.
     error NotEnoughValidSignatures(uint256 validSignatures, uint256 requiredThreshold);
@@ -167,6 +167,10 @@ interface IMinterGateway is IContinuousIndexing, IERC712 {
 
     /// @notice Emitted when updating collateral with a timestamp earlier than allowed.
     error StaleCollateralUpdate(uint40 newTimestamp, uint40 earliestAllowedTimestamp);
+
+    /// @notice Emitted when calling `updateCollateral` with any validator timestamp older than the last signature
+    ///         timestamp for that minter and validator.
+    error OutdatedValidatorTimestamp(address validator, uint256 timestamp, uint256 lastSignatureTimestamp);
 
     /// @notice Emitted when calling `deactivateMinter` with a minter still approved in TTG Registrar.
     error StillApprovedMinter();
@@ -199,7 +203,7 @@ interface IMinterGateway is IContinuousIndexing, IERC712 {
     /// @notice Emitted in constructor if TTG Distribution Vault is set to 0x0 in TTG Registrar.
     error ZeroTTGVault();
 
-    /// @notice Emitted when calling `updateCollateral` if validator timestamp is 0.
+    /// @notice Emitted when calling `updateCollateral` with any validator timestamp of 0.
     error ZeroTimestamp();
 
     /* ============ Interactive Functions ============ */
@@ -364,6 +368,14 @@ interface IMinterGateway is IContinuousIndexing, IERC712 {
 
     /// @notice The timestamp when `minter` created their latest retrieval proposal.
     function latestProposedRetrievalTimestampOf(address minter) external view returns (uint40);
+
+    /**
+     * @notice Returns the last signature timestamp used by `validator` to update collateral for `minter`.
+     * @param  minter    The address of the minter.
+     * @param  validator The address of the validator.
+     * @return The last signature timestamp used.
+     */
+    function getLastSignatureTimestamp(address minter, address validator) external view returns (uint256);
 
     /// @notice The penalty for missed collateral updates. Penalized once per missed interval.
     function getPenaltyForMissedCollateralUpdates(address minter) external view returns (uint240);

--- a/src/interfaces/IMinterGateway.sol
+++ b/src/interfaces/IMinterGateway.sol
@@ -363,7 +363,7 @@ interface IMinterGateway is IContinuousIndexing, IERC712 {
     function penalizedUntilOf(address minter) external view returns (uint40);
 
     /// @notice The timestamp when `minter` created their latest retrieval proposal.
-    function latestProposedRetrievalOf(address minter) external view returns (uint40);
+    function latestProposedRetrievalTimestampOf(address minter) external view returns (uint40);
 
     /// @notice The penalty for missed collateral updates. Penalized once per missed interval.
     function getPenaltyForMissedCollateralUpdates(address minter) external view returns (uint240);

--- a/src/interfaces/IMinterGateway.sol
+++ b/src/interfaces/IMinterGateway.sol
@@ -165,11 +165,8 @@ interface IMinterGateway is IContinuousIndexing, IERC712 {
     ///         If `validators`, `signatures`, `timestamps` lengths do not match.
     error SignatureArrayLengthsMismatch();
 
-    /// @notice Emitted when updating collateral with a timestamp older than the current last update timestamp.
-    error StaleCollateralUpdate(uint40 newTimestamp, uint40 lastCollateralUpdate);
-
-    /// @notice Emitted when updating collateral with a timestamp older than the latest retrieval proposal date.
-    error ObsoleteCollateralUpdate(uint40 newTimestamp, uint40 latestProposedRetrievalTimestamp);
+    /// @notice Emitted when updating collateral with a timestamp earlier than allowed.
+    error StaleCollateralUpdate(uint40 newTimestamp, uint40 earliestAllowedTimestamp);
 
     /// @notice Emitted when calling `deactivateMinter` with a minter still approved in TTG Registrar.
     error StillApprovedMinter();

--- a/src/interfaces/IMinterGateway.sol
+++ b/src/interfaces/IMinterGateway.sol
@@ -165,8 +165,11 @@ interface IMinterGateway is IContinuousIndexing, IERC712 {
     ///         If `validators`, `signatures`, `timestamps` lengths do not match.
     error SignatureArrayLengthsMismatch();
 
-    /// @notice Emitted when calling `updateCollateral` if Minter Gateway has more fresh collateral update.
+    /// @notice Emitted when updating collateral with a timestamp older than the current last update timestamp.
     error StaleCollateralUpdate(uint40 newTimestamp, uint40 lastCollateralUpdate);
+
+    /// @notice Emitted when updating collateral with a timestamp older than the latest retrieval proposal date.
+    error ObsoleteCollateralUpdate(uint40 newTimestamp, uint40 latestProposedRetrievalTimestamp);
 
     /// @notice Emitted when calling `deactivateMinter` with a minter still approved in TTG Registrar.
     error StillApprovedMinter();
@@ -362,6 +365,9 @@ interface IMinterGateway is IContinuousIndexing, IERC712 {
     /// @notice The timestamp until which minter is already penalized for missed collateral updates.
     function penalizedUntilOf(address minter) external view returns (uint40);
 
+    /// @notice The timestamp when `minter` created their latest retrieval proposal.
+    function latestProposedRetrievalOf(address minter) external view returns (uint40);
+
     /// @notice The penalty for missed collateral updates. Penalized once per missed interval.
     function getPenaltyForMissedCollateralUpdates(address minter) external view returns (uint240);
 
@@ -386,10 +392,10 @@ interface IMinterGateway is IContinuousIndexing, IERC712 {
         address minter
     ) external view returns (uint48 mintId, uint40 createdAt, address destination, uint240 amount);
 
-    /// @notice The minter's proposeRetrieval proposal amount
+    /// @notice The amount of a pending retrieval request for an active minter.
     function pendingCollateralRetrievalOf(address minter, uint256 retrievalId) external view returns (uint240);
 
-    /// @notice The total amount of active proposeRetrieval requests per minter
+    /// @notice The total amount of pending retrieval requests for an active minter.
     function totalPendingCollateralRetrievalOf(address minter) external view returns (uint240);
 
     /// @notice The timestamp when minter becomes unfrozen after being frozen by validator.

--- a/test/MinterGateway.t.sol
+++ b/test/MinterGateway.t.sol
@@ -2078,7 +2078,7 @@ contract MinterGatewayTests is TestUtils {
         assertEq(retrievalId, expectedRetrievalId);
         assertEq(_minterGateway.totalPendingCollateralRetrievalOf(_minter1), collateral);
         assertEq(_minterGateway.pendingCollateralRetrievalOf(_minter1, retrievalId), collateral);
-        assertEq(_minterGateway.latestProposedRetrievalOf(_minter1), vm.getBlockTimestamp());
+        assertEq(_minterGateway.latestProposedRetrievalTimestampOf(_minter1), vm.getBlockTimestamp());
         assertEq(_minterGateway.maxAllowedActiveOwedMOf(_minter1), 0);
 
         vm.warp(vm.getBlockTimestamp() + 200);
@@ -2196,7 +2196,7 @@ contract MinterGatewayTests is TestUtils {
         assertEq(retrievalId_, expectedRetrievalId_);
         assertEq(_minterGateway.totalPendingCollateralRetrievalOf(_minter1), minterCollateral_);
         assertEq(_minterGateway.pendingCollateralRetrievalOf(_minter1, retrievalId_), minterCollateral_);
-        assertEq(_minterGateway.latestProposedRetrievalOf(_minter1), vm.getBlockTimestamp());
+        assertEq(_minterGateway.latestProposedRetrievalTimestampOf(_minter1), vm.getBlockTimestamp());
         assertEq(_minterGateway.maxAllowedActiveOwedMOf(_minter1), 0);
 
         vm.warp(vm.getBlockTimestamp() + 200);
@@ -2331,7 +2331,7 @@ contract MinterGatewayTests is TestUtils {
         assertEq(retrievalId, expectedRetrievalId);
         assertEq(_minterGateway.totalPendingCollateralRetrievalOf(_minter1), retrievalAmount);
         assertEq(_minterGateway.pendingCollateralRetrievalOf(_minter1, retrievalId), retrievalAmount);
-        assertEq(_minterGateway.latestProposedRetrievalOf(_minter1), vm.getBlockTimestamp());
+        assertEq(_minterGateway.latestProposedRetrievalTimestampOf(_minter1), vm.getBlockTimestamp());
 
         // Second retrieval proposal
         vm.prank(_minter1);
@@ -2339,7 +2339,7 @@ contract MinterGatewayTests is TestUtils {
 
         assertEq(_minterGateway.totalPendingCollateralRetrievalOf(_minter1), retrievalAmount * 2);
         assertEq(_minterGateway.pendingCollateralRetrievalOf(_minter1, newRetrievalId), retrievalAmount);
-        assertEq(_minterGateway.latestProposedRetrievalOf(_minter1), vm.getBlockTimestamp());
+        assertEq(_minterGateway.latestProposedRetrievalTimestampOf(_minter1), vm.getBlockTimestamp());
 
         uint256[] memory retrievalIds = new uint256[](1);
         retrievalIds[0] = newRetrievalId;
@@ -2412,7 +2412,7 @@ contract MinterGatewayTests is TestUtils {
 
         assertEq(_minterGateway.totalPendingCollateralRetrievalOf(_minter1), retrievalAmount);
         assertEq(_minterGateway.pendingCollateralRetrievalOf(_minter1, retrievalId), retrievalAmount);
-        assertEq(_minterGateway.latestProposedRetrievalOf(_minter1), vm.getBlockTimestamp());
+        assertEq(_minterGateway.latestProposedRetrievalTimestampOf(_minter1), vm.getBlockTimestamp());
 
         // deactivate minter
         _ttgRegistrar.removeFromList(TTGRegistrarReader.MINTERS_LIST, _minter1);
@@ -2453,7 +2453,7 @@ contract MinterGatewayTests is TestUtils {
         assertEq(retrievalId_, expectedRetrievalId_);
         assertEq(_minterGateway.totalPendingCollateralRetrievalOf(_minter1), retrievalAmount_);
         assertEq(_minterGateway.pendingCollateralRetrievalOf(_minter1, retrievalId_), retrievalAmount_);
-        assertEq(_minterGateway.latestProposedRetrievalOf(_minter1), vm.getBlockTimestamp());
+        assertEq(_minterGateway.latestProposedRetrievalTimestampOf(_minter1), vm.getBlockTimestamp());
 
         // Second retrieval proposal
         vm.prank(_minter1);
@@ -2461,7 +2461,7 @@ contract MinterGatewayTests is TestUtils {
 
         assertEq(_minterGateway.totalPendingCollateralRetrievalOf(_minter1), retrievalAmount_ * 2);
         assertEq(_minterGateway.pendingCollateralRetrievalOf(_minter1, newRetrievalId_), retrievalAmount_);
-        assertEq(_minterGateway.latestProposedRetrievalOf(_minter1), vm.getBlockTimestamp());
+        assertEq(_minterGateway.latestProposedRetrievalTimestampOf(_minter1), vm.getBlockTimestamp());
 
         uint256[] memory retrievalIds_ = new uint256[](1);
         retrievalIds_[0] = newRetrievalId_;

--- a/test/utils/MinterGatewayHarness.sol
+++ b/test/utils/MinterGatewayHarness.sol
@@ -116,4 +116,8 @@ contract MinterGatewayHarness is MinterGateway {
     function setIsDeactivated(address minter_, bool isDeactivated_) external {
         _minterStates[minter_].isDeactivated = isDeactivated_;
     }
+
+    function setLastSignatureTimestamp(address minter_, address validator_, uint256 timestamp_) external {
+        _lastSignatureTimestamp[minter_][validator_] = timestamp_;
+    }
 }

--- a/test/utils/MinterGatewayHarness.sol
+++ b/test/utils/MinterGatewayHarness.sol
@@ -77,6 +77,10 @@ contract MinterGatewayHarness is MinterGateway {
         _minterStates[minter_].updateTimestamp = uint40(lastUpdated_);
     }
 
+    function setLatestProposedRetrievalTimestamp(address minter_, uint256 latestProposedRetrieval_) external {
+        _minterStates[minter_].latestProposedRetrievalTimestamp = uint40(latestProposedRetrieval_);
+    }
+
     function setUnfrozenTimeOf(address minter_, uint256 frozenTime_) external {
         _minterStates[minter_].frozenUntilTimestamp = uint40(frozenTime_);
     }


### PR DESCRIPTION
Issue: https://github.com/sherlock-audit/2023-10-mzero-judging/issues/46