### PR TITLE
fix(MinterGateway): improve BurnM

### DIFF
--- a/src/MinterGateway.sol
+++ b/src/MinterGateway.sol
@@ -339,7 +339,11 @@ contract MinterGateway is IMinterGateway, ContinuousIndexing, ERC712Extended {
     ) public returns (uint112 principalAmount_, uint240 amount_) {
         if (maxPrincipalAmount_ == 0 || maxAmount_ == 0) revert ZeroBurnAmount();
 
-        bool isActive_ = _minterStates[minter_].isActive;
+        MinterState memory minterState_ = _minterStates[minter_];
+        bool isActive_ = minterState_.isActive;
+
+        // Revert early if minter has not been activated.
+        if (!isActive_ && !minterState_.isDeactivated) revert InactiveMinter();
 
         if (isActive_) {
             // NOTE: Penalize only for missed collateral updates, not for undercollateralization.

--- a/test/utils/Mocks.sol
+++ b/test/utils/Mocks.sol
@@ -55,13 +55,7 @@ contract MockMToken {
 
     function mint(address account_, uint256 amount_) external {}
 
-    function burn(address /*account_*/, uint256 /*amount_*/) external view {
-        if (_burnFail) revert();
-    }
-
-    function setBurnFail(bool fail_) external {
-        _burnFail = fail_;
-    }
+    function burn(address account_, uint256 amount_) external {}
 
     function setCurrentIndex(uint256 index_) external {
         _currentIndex = index_;


### PR DESCRIPTION
Changelog

`burnM`:
- use `isDeactivated` instead of `isActive` for `if` condition
- if Minter has not been activated, revert early with `InactiveMinter` error