### PR TITLE
Imperfections, last review

### DIFF
--- a/src/MToken.sol
+++ b/src/MToken.sol
@@ -412,11 +412,14 @@ contract MToken is IMToken, ContinuousIndexing, ERC20Extended {
      * @param amount_    The amount (present or principal) to transfer.
      */
     function _transferAmountInKind(address sender_, address recipient_, uint240 amount_) internal {
-        _balances[sender_].rawBalance -= amount_;
+        uint256 rawBalance_ = _balances[sender_].rawBalance;
+
+        if (rawBalance_ < amount_) revert InsufficientBalance(sender_, rawBalance_, amount_);
 
         // NOTE: When transferring an amount in kind, the `rawBalance` can't overflow
         //       since the total supply would have overflowed first when minting.
         unchecked {
+            _balances[sender_].rawBalance -= amount_;
             _balances[recipient_].rawBalance += amount_;
         }
     }

--- a/src/MinterGateway.sol
+++ b/src/MinterGateway.sol
@@ -402,7 +402,7 @@ contract MinterGateway is IMinterGateway, ContinuousIndexing, ERC712Extended {
 
         MinterState storage minterState_ = _minterStates[minter_];
 
-        // NOTE: deactivated once minters cannot be re-activated.
+        // NOTE: Once deactivated, a minter cannot be reactivated.
         if (minterState_.isDeactivated) revert DeactivatedMinter();
 
         minterState_.isActive = true;

--- a/src/MinterGateway.sol
+++ b/src/MinterGateway.sol
@@ -1060,10 +1060,6 @@ contract MinterGateway is IMinterGateway, ContinuousIndexing, ERC712Extended {
     function _revertIfUndercollateralized(address minter_, uint240 additionalOwedM_) internal view {
         uint256 maxAllowedActiveOwedM_ = maxAllowedActiveOwedMOf(minter_);
 
-        // If the minter's max allowed active owed M is greater than the max uint240, then it's definitely greater than
-        // the max possible active owed M for the minter, which is capped at the max uint240.
-        if (maxAllowedActiveOwedM_ >= type(uint240).max) return;
-
         unchecked {
             uint256 finalActiveOwedM_ = uint256(activeOwedMOf(minter_)) + additionalOwedM_;
 

--- a/src/MinterGateway.sol
+++ b/src/MinterGateway.sol
@@ -774,12 +774,12 @@ contract MinterGateway is IMinterGateway, ContinuousIndexing, ERC712Extended {
 
         if (missedIntervals_ == 0) return;
 
+        // Save until when the minter has been penalized for missed intervals to prevent double penalizing them.
+        minterState_.penalizedUntilTimestamp = missedUntil_;
+
         uint112 penaltyPrincipal_ = _imposePenalty(minter_, uint152(principalOfActiveOwedM_) * missedIntervals_);
 
         if (penaltyPrincipal_ == 0) return;
-
-        // Save until when the minter has been penalized for missed intervals to prevent double penalizing them.
-        minterState_.penalizedUntilTimestamp = missedUntil_;
 
         emit MissedIntervalsPenaltyImposed(minter_, missedIntervals_, _getPresentAmount(penaltyPrincipal_));
     }

--- a/src/MinterGateway.sol
+++ b/src/MinterGateway.sol
@@ -63,6 +63,7 @@ contract MinterGateway is IMinterGateway, ContinuousIndexing, ERC712Extended {
      * @param  updateTimestamp         The timestamp at which the minter last updated their collateral.
      * @param  penalizedUntilTimestamp The timestamp until which the minter is penalized.
      * @param  frozenUntilTimestamp    The timestamp until which the minter is frozen.
+     * @param  latestProposedRetrievalTimestamp The timestamp at which the minter last proposed a retrieval.
      */
     struct MinterState {
         // 1st slot
@@ -196,6 +197,10 @@ contract MinterGateway is IMinterGateway, ContinuousIndexing, ERC712Extended {
             signatures_
         );
 
+        _imposePenaltyIfMissedCollateralUpdates(msg.sender);
+
+        _imposePenaltyIfUndercollateralized(msg.sender, minTimestamp_);
+
         uint240 safeCollateral_ = UIntMath.safe240(collateral_);
         uint240 totalResolvedCollateralRetrieval_ = _resolvePendingRetrievals(msg.sender, retrievalIds_);
 
@@ -206,10 +211,6 @@ contract MinterGateway is IMinterGateway, ContinuousIndexing, ERC712Extended {
             metadataHash_,
             minTimestamp_
         );
-
-        _imposePenaltyIfMissedCollateralUpdates(msg.sender);
-
-        _imposePenaltyIfUndercollateralized(msg.sender, minTimestamp_);
 
         _updateCollateral(msg.sender, safeCollateral_, minTimestamp_);
 

--- a/src/MinterGateway.sol
+++ b/src/MinterGateway.sol
@@ -774,12 +774,12 @@ contract MinterGateway is IMinterGateway, ContinuousIndexing, ERC712Extended {
 
         if (missedIntervals_ == 0) return;
 
-        // Save until when the minter has been penalized for missed intervals to prevent double penalizing them.
-        minterState_.penalizedUntilTimestamp = missedUntil_;
-
         uint112 penaltyPrincipal_ = _imposePenalty(minter_, uint152(principalOfActiveOwedM_) * missedIntervals_);
 
         if (penaltyPrincipal_ == 0) return;
+
+        // Save until when the minter has been penalized for missed intervals to prevent double penalizing them.
+        minterState_.penalizedUntilTimestamp = missedUntil_;
 
         emit MissedIntervalsPenaltyImposed(minter_, missedIntervals_, _getPresentAmount(penaltyPrincipal_));
     }

--- a/test/MToken.t.sol
+++ b/test/MToken.t.sol
@@ -392,7 +392,7 @@ contract MTokenTests is TestUtils {
     function test_transfer_insufficientBalance_fromNonEarner_toNonEarner() external {
         _mToken.setInternalBalanceOf(_alice, 999);
 
-        vm.expectRevert(stdError.arithmeticError);
+        vm.expectRevert(abi.encodeWithSelector(IMToken.InsufficientBalance.selector, _alice, 999, 1_000));
         vm.prank(_alice);
         _mToken.transfer(_bob, 1_000);
     }

--- a/test/MinterGateway.t.sol
+++ b/test/MinterGateway.t.sol
@@ -1732,6 +1732,8 @@ contract MinterGatewayTests is TestUtils {
 
         uint240 activeOwedM_ = _minterGateway.activeOwedMOf(_minter1);
 
+        if (activeOwedM_ == 0) return; // No penalty if there is no active owed M
+
         vm.prank(_minter1);
         _minterGateway.updateCollateral(
             minterCollateral_,
@@ -2036,6 +2038,8 @@ contract MinterGatewayTests is TestUtils {
         );
 
         uint240 activeOwedM_ = _minterGateway.activeOwedMOf(_minter1);
+
+        if (activeOwedM_ == 0) return; // No penalties to impose if no M is owed.
 
         vm.prank(_minter1);
         _minterGateway.updateCollateral(

--- a/test/MinterGateway.t.sol
+++ b/test/MinterGateway.t.sol
@@ -1747,7 +1747,7 @@ contract MinterGatewayTests is TestUtils {
         // 1 wei difference because of rounding
         assertApproxEqAbs(_minterGateway.activeOwedMOf(_minter1), activeOwedM_ + missedUpdatesPenalty_, 1);
 
-        vm.assume(principalOfMissedUpdatesPenalty_ != 0) return; // No change in `penalizedUntilTimestamp` if there are no missed updates
+        vm.assume(principalOfMissedUpdatesPenalty_ != 0); // No change in `penalizedUntilTimestamp` if there are no missed updates
 
         assertEq(_minterGateway.penalizedUntilOf(_minter1), vm.getBlockTimestamp() - (_updateCollateralInterval / 2));
     }
@@ -2065,7 +2065,7 @@ contract MinterGatewayTests is TestUtils {
             1
         );
 
-        vm.assume(principalOfMissedUpdatePenalty_ != 0) return; // No change in penalizedUntil if there are no missed updates
+        vm.assume(principalOfMissedUpdatePenalty_ != 0); // No change in penalizedUntil if there are no missed updates
 
         assertEq(
             _minterGateway.penalizedUntilOf(_minter1),

--- a/test/MinterGateway.t.sol
+++ b/test/MinterGateway.t.sol
@@ -1747,7 +1747,7 @@ contract MinterGatewayTests is TestUtils {
         // 1 wei difference because of rounding
         assertApproxEqAbs(_minterGateway.activeOwedMOf(_minter1), activeOwedM_ + missedUpdatesPenalty_, 1);
 
-        if (principalOfMissedUpdatesPenalty_ == 0) return; // No change in `penalizedUntilTimestamp` if there are no missed updates
+        vm.assume(principalOfMissedUpdatesPenalty_ != 0) return; // No change in `penalizedUntilTimestamp` if there are no missed updates
 
         assertEq(_minterGateway.penalizedUntilOf(_minter1), vm.getBlockTimestamp() - (_updateCollateralInterval / 2));
     }
@@ -2065,7 +2065,7 @@ contract MinterGatewayTests is TestUtils {
             1
         );
 
-        if (principalOfMissedUpdatePenalty_ == 0) return; // No change in penalizedUntil if there are no missed updates
+        vm.assume(principalOfMissedUpdatePenalty_ != 0) return; // No change in penalizedUntil if there are no missed updates
 
         assertEq(
             _minterGateway.penalizedUntilOf(_minter1),

--- a/test/MinterGateway.t.sol
+++ b/test/MinterGateway.t.sol
@@ -1732,7 +1732,7 @@ contract MinterGatewayTests is TestUtils {
 
         uint240 activeOwedM_ = _minterGateway.activeOwedMOf(_minter1);
 
-        if (activeOwedM_ == 0) return; // No penalty if there is no active owed M
+        vm.assume(activeOwedM_ != 0); // No penalty if there is no active owed M
 
         vm.prank(_minter1);
         _minterGateway.updateCollateral(
@@ -2042,7 +2042,7 @@ contract MinterGatewayTests is TestUtils {
 
         uint240 activeOwedM_ = _minterGateway.activeOwedMOf(_minter1);
 
-        if (activeOwedM_ == 0) return; // No penalties to impose if no M is owed.
+        vm.assume(activeOwedM_ != 0); // No penalties to impose if no M is owed.
 
         vm.prank(_minter1);
         _minterGateway.updateCollateral(

--- a/test/MinterGateway.t.sol
+++ b/test/MinterGateway.t.sol
@@ -1746,6 +1746,9 @@ contract MinterGatewayTests is TestUtils {
 
         // 1 wei difference because of rounding
         assertApproxEqAbs(_minterGateway.activeOwedMOf(_minter1), activeOwedM_ + missedUpdatesPenalty_, 1);
+
+        if (principalOfMissedUpdatesPenalty_ == 0) return; // No change in `penalizedUntilTimestamp` if there are no missed updates
+
         assertEq(_minterGateway.penalizedUntilOf(_minter1), vm.getBlockTimestamp() - (_updateCollateralInterval / 2));
     }
 
@@ -2061,6 +2064,8 @@ contract MinterGatewayTests is TestUtils {
                 ),
             1
         );
+
+        if (principalOfMissedUpdatePenalty_ == 0) return; // No change in penalizedUntil if there are no missed updates
 
         assertEq(
             _minterGateway.penalizedUntilOf(_minter1),


### PR DESCRIPTION
- Missing comment
- Impose penalties, only then resolve retrievals
- `penalizedUntilTimestamp` update later in the method
- emit `InsufficientBalance` event in `_transferAmountInKind`