### PR TITLE
Adjust EarnerRateModel to be less conservative

### DIFF
--- a/script/DeployEarnerRateModel.s.sol
+++ b/script/DeployEarnerRateModel.s.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.23;
+
+import { Script, console2 } from "../lib/forge-std/src/Script.sol";
+import { EarnerRateModel } from "../src/rateModels/EarnerRateModel.sol";
+
+contract DeployEarnerRateModel is Script {
+    // NOTE: Ensure this is the correct MinterGateway testnet/mainnet address.
+    address internal constant _MINTER_GATEWAY = 0xf7f9638cb444D65e5A40bF5ff98ebE4ff319F04E; //mainnet
+    // address internal constant _MINTER_GATEWAY = 0x4eDfcfB5F9e55962EF1A2eEf0b56A8FaDbaBA289; // sepolia
+
+    function run() external {
+        address deployer_ = vm.rememberKey(vm.envUint("PRIVATE_KEY"));
+
+        console2.log("Deployer:", deployer_);
+
+        vm.startBroadcast(deployer_);
+
+        address earnerRateModel_ = address(new EarnerRateModel(_MINTER_GATEWAY));
+
+        vm.stopBroadcast();
+
+        console2.log("Earner Rate Model address:", earnerRateModel_);
+    }
+}

--- a/src/rateModels/EarnerRateModel.sol
+++ b/src/rateModels/EarnerRateModel.sol
@@ -16,7 +16,7 @@ import { IEarnerRateModel } from "./interfaces/IEarnerRateModel.sol";
 
 /**
  * @title  Earner Rate Model contract set in TTG (Two Token Governance) Registrar and accessed by MToken.
- * @author M^0 Labs
+ * @author M0 Labs
  */
 contract EarnerRateModel is IEarnerRateModel {
     /* ============ Variables ============ */


### PR DESCRIPTION
Adjust EarnerRate to be less conservative. Particularly if `earnerRate` <=  `minterRate`, and no deactivated  were in the system, return `earnerRate`

With current state of protocol where `minterRate` == TTG set `earnerRate`, effective earner rate does not require safety rate multiplier adjustments